### PR TITLE
[MTC-9153] Fix multiselect action reference

### DIFF
--- a/Config/config.php
+++ b/Config/config.php
@@ -3,7 +3,7 @@
 return [
     'name'        => 'Multiselect Handling by Leuchtfeuer',
     'description' => 'Provides custom actions to manage multiselect fields.',
-    'version'     => '3.1.1',
+    'version'     => '3.1.2',
     'author'      => 'Leuchtfeuer Digital Marketing GmbH',
     'services'    => [
         'other' => [

--- a/EventListener/FormAction.php
+++ b/EventListener/FormAction.php
@@ -144,78 +144,62 @@ class FormAction implements EventSubscriberInterface
             return; // no lead to update
         }
 
-        $actions = $event->getForm()->getActions();
-        $enable  = false;
-        foreach ($actions as $action) {
-            if (FormSubscriber::ACTION_MULTISELECT_CONTACT === $action->getType()) {
-                $enable = true;
-                break;
-            }
-        }
-        if (!$enable) {
-            return;
-        }
-
+        $action = $event->getAction();
         $fields = [
             UpdateSelectFieldType::ADD    => [],
             UpdateSelectFieldType::REMOVE => [],
         ];
 
-        foreach ($actions as $action) {
-            if (FormSubscriber::ACTION_MULTISELECT_CONTACT !== $action->getType()) {
+        $values = $action->getProperties();
+        foreach ($fields as $key => $item) {
+            if (isset($values[$key])) {
+                if (is_string($values[$key]) && '' !== $values[$key]) {
+                    $fields[$key] = [$values[$key]];
+                    continue;
+                }
+
+                if (is_array($values[$key]) && [] !== $values[$key]) {
+                    $fields[$key] = $values[$key];
+                    continue;
+                }
+
+                if (!is_array($values[$key]) && !is_string($values[$key])) {
+                    throw new \RuntimeException('Field values has an incompatible type.');
+                }
+            }
+        }
+
+        if (null === $field = $this->getCurrentField($lead, (int) $values[UpdateSelectFieldType::FIELD])) {
+            return; // field is not in contact
+        }
+
+        $currentValue = $this->getFieldValue($field);
+
+        foreach ($fields[UpdateSelectFieldType::ADD] as $idAliasToAdd) {
+            $aliasToAdd = SegmentsModel::splitAliasId($idAliasToAdd)['alias'];
+            if (in_array($aliasToAdd, $currentValue, true)) {
                 continue;
             }
-            $values = $action->getProperties();
-            foreach ($fields as $key => $item) {
-                if (isset($values[$key])) {
-                    if (is_string($values[$key]) && '' !== $values[$key]) {
-                        $fields[$key] = [$values[$key]];
-                        continue;
-                    }
 
-                    if (is_array($values[$key]) && [] !== $values[$key]) {
-                        $fields[$key] = $values[$key];
-                        continue;
-                    }
-
-                    if (!is_array($values[$key]) && !is_string($values[$key])) {
-                        throw new \RuntimeException('Field values has an incompatible type.');
-                    }
-                }
-            }
-
-            if (null === $field = $this->getCurrentField($lead, (int) $values[UpdateSelectFieldType::FIELD])) {
-                return; // field is not in contact
-            }
-
-            $currentValue = $this->getFieldValue($field);
-
-            foreach ($fields[UpdateSelectFieldType::ADD] as $idAliasToAdd) {
-                $aliasToAdd = SegmentsModel::splitAliasId($idAliasToAdd)['alias'];
-                if (in_array($aliasToAdd, $currentValue, true)) {
-                    continue;
-                }
-
-                $currentValue[] = $aliasToAdd;
-            }
-
-            foreach ($fields[UpdateSelectFieldType::REMOVE] as $idAliasToRemove) {
-                $aliasToRemove = SegmentsModel::splitAliasId($idAliasToRemove)['alias'];
-                if (false === $index = array_search($aliasToRemove, $currentValue, true)) {
-                    continue;
-                }
-
-                unset($currentValue[$index]);
-            }
-
-            $fieldValue = array_filter(array_values($currentValue));
-
-            if ('select' === $field['type']) {
-                $fieldValue = count($fieldValue) > 0 ? array_pop($fieldValue) : null;
-            }
-            $this->leadModel->setFieldValues($lead, [$field['alias'] => $fieldValue], true);
-            $this->leadModel->saveEntity($lead);
+            $currentValue[] = $aliasToAdd;
         }
+
+        foreach ($fields[UpdateSelectFieldType::REMOVE] as $idAliasToRemove) {
+            $aliasToRemove = SegmentsModel::splitAliasId($idAliasToRemove)['alias'];
+            if (false === $index = array_search($aliasToRemove, $currentValue, true)) {
+                continue;
+            }
+
+            unset($currentValue[$index]);
+        }
+
+        $fieldValue = array_filter(array_values($currentValue));
+
+        if ('select' === $field['type']) {
+            $fieldValue = count($fieldValue) > 0 ? array_pop($fieldValue) : null;
+        }
+        $this->leadModel->setFieldValues($lead, [$field['alias'] => $fieldValue], true);
+        $this->leadModel->saveEntity($lead);
     }
 
     /**


### PR DESCRIPTION
This PR fixes the issue with custom actions dispatch (like DOI plugin). 
There is no need to loop over all the form actions to find the current one. Instead we should depend on action that is passed by the event: `$action = $event->getAction();` when the event context is: `FormSubscriber::ACTION_MULTISELECT_CONTACT`

Steps to test (everything should work as before for regular Mautic instance):
1. Create a form with `Change contact's multiselect field` action
2. Submit the form as contact
3. Verify if the contact has chosen multiselect fields assigned