### PR TITLE
MTC-9168 fix create missing segments switch

### DIFF
--- a/EventListener/ActionSubscriber.php
+++ b/EventListener/ActionSubscriber.php
@@ -121,7 +121,7 @@ class ActionSubscriber implements EventSubscriberInterface
 
         $values = $event->getConfig();
 
-        if (!isset($values[SettingsType::FIELD], $values[SettingsType::CHECKBOX])) {
+        if (!isset($values[SettingsType::FIELD]) || !array_key_exists(SettingsType::CHECKBOX, $values)) {
             throw new \RuntimeException('Invalid event configuration.');
         }
 

--- a/EventListener/FormAction.php
+++ b/EventListener/FormAction.php
@@ -10,7 +10,6 @@ use Mautic\LeadBundle\Entity\Lead;
 use Mautic\LeadBundle\Entity\LeadList;
 use Mautic\LeadBundle\Model\LeadModel;
 use MauticPlugin\LeuchtfeuerMultiselectHandlingBundle\Exception\InvalidSetupException;
-use MauticPlugin\LeuchtfeuerMultiselectHandlingBundle\Exception\NonExistingListException;
 use MauticPlugin\LeuchtfeuerMultiselectHandlingBundle\Exception\UnexpectedTypeException;
 use MauticPlugin\LeuchtfeuerMultiselectHandlingBundle\Form\Loader\LeadFieldChoiceLoader;
 use MauticPlugin\LeuchtfeuerMultiselectHandlingBundle\Form\Type\SettingsType;

--- a/EventListener/FormAction.php
+++ b/EventListener/FormAction.php
@@ -92,8 +92,6 @@ class FormAction implements EventSubscriberInterface
             }
         } catch (InvalidSetupException) {
             throw new ValidationException($this->translator->trans(self::INVALID_SETUP));
-        } catch (NonExistingListException) {
-            throw new ValidationException($this->translator->trans(self::NON_EXISTING_LIST));
         }
 
         /** @var LeadList[] $currentSegments */

--- a/EventListener/FormAction.php
+++ b/EventListener/FormAction.php
@@ -56,7 +56,7 @@ class FormAction implements EventSubscriberInterface
 
         $actionProperties = $action->getProperties();
 
-        if (!isset($actionProperties[SettingsType::FIELD], $actionProperties[SettingsType::CHECKBOX])) {
+        if (!isset($actionProperties[SettingsType::FIELD]) || !array_key_exists(SettingsType::CHECKBOX, $actionProperties)) {
             throw new ValidationException('Seems like you do not have proper SettingsType.');
         }
 

--- a/Model/SegmentsModel.php
+++ b/Model/SegmentsModel.php
@@ -7,7 +7,6 @@ namespace MauticPlugin\LeuchtfeuerMultiselectHandlingBundle\Model;
 use Mautic\LeadBundle\Entity\LeadList;
 use Mautic\LeadBundle\Model\ListModel;
 use MauticPlugin\LeuchtfeuerMultiselectHandlingBundle\Exception\InvalidSetupException;
-use MauticPlugin\LeuchtfeuerMultiselectHandlingBundle\Exception\NonExistingListException;
 use MauticPlugin\LeuchtfeuerMultiselectHandlingBundle\Form\Loader\LeadFieldChoiceLoader;
 
 class SegmentsModel
@@ -17,9 +16,9 @@ class SegmentsModel
     }
 
     /**
-     * @return array<int, string>|null
+     * @return array<int, string>
      */
-    public function getSegments(int $multiselectFieldId, bool $createNew): ?array
+    public function getSegments(int $multiselectFieldId, bool $createNew): array
     {
         $choices = $this->leadFieldChoiceLoader->loadFieldsForChoices([$multiselectFieldId]);
 
@@ -50,17 +49,13 @@ class SegmentsModel
 
                     $this->listModel->saveEntity($newSegment);
                     $segments[$newSegment->getId()] = $newSegment->getAlias();
-
-                    continue;
                 }
-
-                throw new NonExistingListException();
+                continue;
             }
 
             $segmentData = array_pop($segmentsData);
-
             if (!is_array($segmentData) || !isset($segmentData['id'], $segmentData['alias'])) {
-                return null;
+                continue;
             }
 
             $segments[(int) $segmentData['id']] = $segmentData['alias'];

--- a/Tests/Functional/CampaignSegmentsFunctionalTest.php
+++ b/Tests/Functional/CampaignSegmentsFunctionalTest.php
@@ -602,7 +602,7 @@ class CampaignSegmentsFunctionalTest extends MauticMysqlTestCase
         $event->setTriggerMode('immediate');
         $event->setProperties([
             SettingsType::FIELD    => $fieldId,
-            SettingsType::CHECKBOX => $createMissing ? '1' : '0',
+            SettingsType::CHECKBOX => $createMissing ? '1' : null,
         ]);
 
         $this->em->persist($event);

--- a/Tests/Functional/FormActionSegmentsFunctionalTest.php
+++ b/Tests/Functional/FormActionSegmentsFunctionalTest.php
@@ -477,7 +477,7 @@ class FormActionSegmentsFunctionalTest extends MauticMysqlTestCase
                     'type'        => FormSubscriber::ACTION,
                     'properties'  => [
                         SettingsType::FIELD    => $fieldId,
-                        SettingsType::CHECKBOX => $createMissing ? '1' : '0',
+                        SettingsType::CHECKBOX => $createMissing ? '1' : null,
                     ],
                     'order'       => 1,
                 ],

--- a/Tests/Functional/FormActionSegmentsFunctionalTest.php
+++ b/Tests/Functional/FormActionSegmentsFunctionalTest.php
@@ -245,8 +245,8 @@ class FormActionSegmentsFunctionalTest extends MauticMysqlTestCase
             'mauticform[select_segments]' => [$segments[0]['alias'], $segments[2]['alias'], $createdSegmentAlias],
         ]);
 
-        // adds: api-segment-d
-        // removes: api-segment-c
+        // adds: api-segment-c
+        // removes: api-segment-d
         // unchanged: api-segment-a (selected by user)
         // unchanged: api-segment-b (not in the $selectedSegments list)
         $this->client->submit($form);

--- a/Tests/Functional/FormActionSegmentsFunctionalTest.php
+++ b/Tests/Functional/FormActionSegmentsFunctionalTest.php
@@ -225,11 +225,13 @@ class FormActionSegmentsFunctionalTest extends MauticMysqlTestCase
     public function testFunctionalMultiselectWithoutCreatingMissingButMissingSegment(): void
     {
         $selectedSegments    = $segments = $this->created['segments'] = $this->createSegments();
+        unset($selectedSegments[1]); // removed: api-segment-b
         $createdSegmentAlias = 'createdsegmentname';
         $fieldId             = $this->created['contact_field'] = $this->testCreateMultiselectField(array_merge($selectedSegments, [['name' => 'Created segment name', 'alias' => $createdSegmentAlias]]));
         $contact             = $this->created['contact'] = $this->createContact();
         $formId              = $this->created['form'] = $this->createForm($fieldId, false, true);
 
+        // api-segment-a, api-segment-b, api-segment-d
         $this->leadModel->addToLists(['id' => $contact['id']], [$segments[0]['id'], $segments[1]['id'], $segments[3]['id']]);
 
         $crawler     = $this->client->request(Request::METHOD_GET, '/form/'.$formId);
@@ -239,8 +241,14 @@ class FormActionSegmentsFunctionalTest extends MauticMysqlTestCase
         $form->disableValidation();
         $form->setValues([
             'mauticform[email]'           => $contact['fields']['core']['email']['value'],
+            // api-segment-a, api-segment-c, createdsegmentname
             'mauticform[select_segments]' => [$segments[0]['alias'], $segments[2]['alias'], $createdSegmentAlias],
         ]);
+
+        // adds: api-segment-d
+        // removes: api-segment-c
+        // unchanged: api-segment-a (selected by user)
+        // unchanged: api-segment-b (not in the $selectedSegments list)
         $this->client->submit($form);
 
         $clientResponse = $this->client->getResponse();
@@ -252,18 +260,16 @@ class FormActionSegmentsFunctionalTest extends MauticMysqlTestCase
         $clientResponse = $this->client->getResponse();
         self::assertSame(Response::HTTP_OK, $clientResponse->getStatusCode(), $clientResponse->getContent());
 
-        $this->em->clear();
-
         /** @var LeadListRepository $leadListRepository */
         $leadListRepository = $this->leadModel->getLeadListRepository();
         /** @var LeadList[] $lists */
         $lists = $leadListRepository->getLeadLists($contact['id']);
 
-        self::assertCount(2, $lists);
-        $list = array_pop($lists);
-        self::assertSame($segments[2]['id'], $list->getId());
-        $list = array_pop($lists);
-        self::assertSame($segments[0]['id'], $list->getId());
+        $actualAliases = array_map(fn (LeadList $list) => $list->getAlias(), $lists);
+        self::assertCount(3, $actualAliases);
+        self::assertContains($segments[0]['alias'], $actualAliases); // api-segment-a
+        self::assertContains($segments[1]['alias'], $actualAliases); // api-segment-b
+        self::assertContains($segments[2]['alias'], $actualAliases); // api-segment-c
     }
 
     public function testFunctionalSingleSelectWithoutCreatingMissing(): void

--- a/Tests/Functional/FormActionSegmentsFunctionalTest.php
+++ b/Tests/Functional/FormActionSegmentsFunctionalTest.php
@@ -225,7 +225,6 @@ class FormActionSegmentsFunctionalTest extends MauticMysqlTestCase
     public function testFunctionalMultiselectWithoutCreatingMissingButMissingSegment(): void
     {
         $selectedSegments = $segments = $this->created['segments'] = $this->createSegments();
-        unset($selectedSegments[1]);
         $createdSegmentAlias = 'createdsegmentname';
         $fieldId             = $this->created['contact_field'] = $this->testCreateMultiselectField(array_merge($selectedSegments, [['name' => 'Created segment name', 'alias' => $createdSegmentAlias]]));
         $contact             = $this->created['contact'] = $this->createContact();
@@ -247,22 +246,22 @@ class FormActionSegmentsFunctionalTest extends MauticMysqlTestCase
         $clientResponse = $this->client->getResponse();
 
         self::assertSame(Response::HTTP_FOUND, $clientResponse->getStatusCode(), $clientResponse->getContent());
-        self::assertSame('https://localhost/form/'.$formId.'?mauticError=Errors%3A%3Cbr%20%2F%3E%3Col%3E%3Cli%3EGiven%20list%20does%20not%20exist.%3C%2Fli%3E%3C%2Fol%3E#submission', $clientResponse->headers->get('Location'));
+        self::assertSame('https://localhost/form/'.$formId, $clientResponse->headers->get('Location'));
         $this->client->followRedirect();
 
         $clientResponse = $this->client->getResponse();
         self::assertSame(Response::HTTP_OK, $clientResponse->getStatusCode(), $clientResponse->getContent());
+
+        $this->em->clear();
 
         /** @var LeadListRepository $leadListRepository */
         $leadListRepository = $this->leadModel->getLeadListRepository();
         /** @var LeadList[] $lists */
         $lists = $leadListRepository->getLeadLists($contact['id']);
 
-        self::assertCount(3, $lists);
+        self::assertCount(2, $lists);
         $list = array_pop($lists);
-        self::assertSame($segments[3]['id'], $list->getId());
-        $list = array_pop($lists);
-        self::assertSame($segments[1]['id'], $list->getId());
+        self::assertSame($segments[2]['id'], $list->getId());
         $list = array_pop($lists);
         self::assertSame($segments[0]['id'], $list->getId());
     }
@@ -400,7 +399,6 @@ class FormActionSegmentsFunctionalTest extends MauticMysqlTestCase
     public function testFunctionalSingleSelectWithoutCreatingMissingButMissingSegment(): void
     {
         $selectedSegments = $segments = $this->created['segments'] = $this->createSegments();
-        unset($selectedSegments[1]);
         $createdSegmentAlias = 'createdsegmentname';
         $fieldId             = $this->created['contact_field'] = $this->testCreateSingleSelectField(array_merge($selectedSegments, [['name' => 'Created segment name', 'alias' => $createdSegmentAlias]]));
         $contact             = $this->created['contact'] = $this->createContact();
@@ -422,7 +420,7 @@ class FormActionSegmentsFunctionalTest extends MauticMysqlTestCase
         $clientResponse = $this->client->getResponse();
 
         self::assertSame(Response::HTTP_FOUND, $clientResponse->getStatusCode(), $clientResponse->getContent());
-        self::assertSame('https://localhost/form/'.$formId.'?mauticError=Errors%3A%3Cbr%20%2F%3E%3Col%3E%3Cli%3EGiven%20list%20does%20not%20exist.%3C%2Fli%3E%3C%2Fol%3E#submission', $clientResponse->headers->get('Location'));
+        self::assertSame('https://localhost/form/'.$formId, $clientResponse->headers->get('Location'));
         $this->client->followRedirect();
 
         $clientResponse = $this->client->getResponse();
@@ -433,13 +431,47 @@ class FormActionSegmentsFunctionalTest extends MauticMysqlTestCase
         /** @var LeadList[] $lists */
         $lists = $leadListRepository->getLeadLists($contact['id']);
 
-        self::assertCount(3, $lists);
+        self::assertCount(0, $lists);
+    }
+
+    public function testFunctionalSingleSelectWithMissingSegmentsIgnored(): void
+    {
+        $selectedSegments = $segments = $this->created['segments'] = $this->createSegments();
+        $createdSegmentAlias = 'createdsegmentname';
+        $fieldId             = $this->created['contact_field'] = $this->testCreateSingleSelectField(array_merge($selectedSegments, [['name' => 'Created segment name', 'alias' => $createdSegmentAlias]]));
+        $contact             = $this->created['contact'] = $this->createContact();
+        $formId              = $this->created['form'] = $this->createForm($fieldId, false, false);
+
+        $this->leadModel->addToLists(['id' => $contact['id']], [$segments[0]['id'], $segments[1]['id'], $segments[3]['id']]);
+
+        $crawler     = $this->client->request(Request::METHOD_GET, '/form/'.$formId);
+        $formCrawler = $crawler->filter('form[id=mauticform_submissiontestform]');
+        self::assertCount(1, $formCrawler, (string) $this->client->getResponse()->getContent());
+        $form = $formCrawler->form();
+        $form->disableValidation();
+        $form->setValues([
+            'mauticform[email]'           => $contact['fields']['core']['email']['value'],
+            'mauticform[select_segments]' => $segments[2]['alias'],
+        ]);
+        $this->client->submit($form);
+
+        $clientResponse = $this->client->getResponse();
+
+        self::assertSame(Response::HTTP_FOUND, $clientResponse->getStatusCode(), $clientResponse->getContent());
+        self::assertSame('https://localhost/form/'.$formId, $clientResponse->headers->get('Location'));
+        $this->client->followRedirect();
+
+        $clientResponse = $this->client->getResponse();
+        self::assertSame(Response::HTTP_OK, $clientResponse->getStatusCode(), $clientResponse->getContent());
+
+        /** @var LeadListRepository $leadListRepository */
+        $leadListRepository = $this->leadModel->getLeadListRepository();
+        /** @var LeadList[] $lists */
+        $lists = $leadListRepository->getLeadLists($contact['id']);
+
+        self::assertCount(1, $lists);
         $list = array_pop($lists);
-        self::assertSame($segments[3]['id'], $list->getId());
-        $list = array_pop($lists);
-        self::assertSame($segments[1]['id'], $list->getId());
-        $list = array_pop($lists);
-        self::assertSame($segments[0]['id'], $list->getId());
+        self::assertSame($segments[2]['id'], $list->getId());
     }
 
     private function createForm(int $fieldId, bool $createMissing, bool $multiSelect): int

--- a/Tests/Functional/FormActionSegmentsFunctionalTest.php
+++ b/Tests/Functional/FormActionSegmentsFunctionalTest.php
@@ -224,7 +224,7 @@ class FormActionSegmentsFunctionalTest extends MauticMysqlTestCase
 
     public function testFunctionalMultiselectWithoutCreatingMissingButMissingSegment(): void
     {
-        $selectedSegments = $segments = $this->created['segments'] = $this->createSegments();
+        $selectedSegments    = $segments = $this->created['segments'] = $this->createSegments();
         $createdSegmentAlias = 'createdsegmentname';
         $fieldId             = $this->created['contact_field'] = $this->testCreateMultiselectField(array_merge($selectedSegments, [['name' => 'Created segment name', 'alias' => $createdSegmentAlias]]));
         $contact             = $this->created['contact'] = $this->createContact();
@@ -398,7 +398,7 @@ class FormActionSegmentsFunctionalTest extends MauticMysqlTestCase
 
     public function testFunctionalSingleSelectWithoutCreatingMissingButMissingSegment(): void
     {
-        $selectedSegments = $segments = $this->created['segments'] = $this->createSegments();
+        $selectedSegments    = $segments = $this->created['segments'] = $this->createSegments();
         $createdSegmentAlias = 'createdsegmentname';
         $fieldId             = $this->created['contact_field'] = $this->testCreateSingleSelectField(array_merge($selectedSegments, [['name' => 'Created segment name', 'alias' => $createdSegmentAlias]]));
         $contact             = $this->created['contact'] = $this->createContact();
@@ -436,7 +436,7 @@ class FormActionSegmentsFunctionalTest extends MauticMysqlTestCase
 
     public function testFunctionalSingleSelectWithMissingSegmentsIgnored(): void
     {
-        $selectedSegments = $segments = $this->created['segments'] = $this->createSegments();
+        $selectedSegments    = $segments = $this->created['segments'] = $this->createSegments();
         $createdSegmentAlias = 'createdsegmentname';
         $fieldId             = $this->created['contact_field'] = $this->testCreateSingleSelectField(array_merge($selectedSegments, [['name' => 'Created segment name', 'alias' => $createdSegmentAlias]]));
         $contact             = $this->created['contact'] = $this->createContact();

--- a/Tests/Unit/EventListener/ActionSubscriberTest.php
+++ b/Tests/Unit/EventListener/ActionSubscriberTest.php
@@ -494,7 +494,7 @@ class ActionSubscriberTest extends TestCase
         $subscriber->onManageSegmentsAction($event);
     }
 
-    public function testManageSegmentsActionInvalidSegments(): void
+    public function testManageSegmentsActionNotExistingSegments(): void
     {
         $config                    = $this->createMock(Config::class);
         $config->expects(self::once())
@@ -536,10 +536,7 @@ class ActionSubscriberTest extends TestCase
         $segmentsModel->expects(self::once())
             ->method('getSegments')
             ->with($fieldId, false)
-            ->willReturn(null);
-
-        $this->expectException(\LogicException::class);
-        $this->expectExceptionMessage('Invalid setup.');
+            ->willReturn([]);
 
         $subscriber = new ActionSubscriber($config, $leadModel, $segmentsModel);
         $subscriber->onManageSegmentsAction($event);

--- a/Tests/Unit/EventListener/FormActionTest.php
+++ b/Tests/Unit/EventListener/FormActionTest.php
@@ -16,7 +16,6 @@ use Mautic\LeadBundle\Entity\LeadList;
 use Mautic\LeadBundle\Model\LeadModel;
 use MauticPlugin\LeuchtfeuerMultiselectHandlingBundle\EventListener\FormAction;
 use MauticPlugin\LeuchtfeuerMultiselectHandlingBundle\EventListener\FormSubscriber;
-use MauticPlugin\LeuchtfeuerMultiselectHandlingBundle\Exception\NonExistingListException;
 use MauticPlugin\LeuchtfeuerMultiselectHandlingBundle\Form\Loader\LeadFieldChoiceLoader;
 use MauticPlugin\LeuchtfeuerMultiselectHandlingBundle\Form\Type\SettingsType;
 use MauticPlugin\LeuchtfeuerMultiselectHandlingBundle\Integration\Config;

--- a/Tests/Unit/EventListener/FormActionTest.php
+++ b/Tests/Unit/EventListener/FormActionTest.php
@@ -387,7 +387,7 @@ class FormActionTest extends TestCase
         $formAction->onAction($event);
     }
 
-    public function testOnActionInvalidSegments(): void
+    public function testOnActionNonExistingSegments(): void
     {
         $leadFieldChoiceLoader     = $this->createMock(LeadFieldChoiceLoader::class);
         $translator                = $this->createMock(TranslatorInterface::class);
@@ -435,25 +435,20 @@ class FormActionTest extends TestCase
             ->method('getAlias')
             ->willReturn($leadFieldAlias);
 
-        $translator->expects(self::once())
-            ->method('trans')
-            ->with(FormAction::INVALID_SETUP)
-            ->willReturn($exceptionMessage);
-
         $segmentsModel->expects(self::once())
             ->method('getSegments')
             ->with($fieldId, false)
-            ->willReturn(null);
+            ->willReturn([]);
 
-        $leadModel->expects(self::never())
-            ->method('getLists');
+        $leadModel->expects(self::once())
+            ->method('getLists')
+            ->with($lead)
+            ->willReturn([]);
+
         $leadModel->expects(self::never())
             ->method('removeFromLists');
         $leadModel->expects(self::never())
             ->method('addToLists');
-
-        $this->expectException(ValidationException::class);
-        $this->expectExceptionMessage($exceptionMessage);
 
         $formAction = new FormAction($config, $leadFieldChoiceLoader, $translator, $leadModel, $segmentsModel);
         $formAction->onAction($event);
@@ -483,7 +478,6 @@ class FormActionTest extends TestCase
         $config                    = $this->createMock(Config::class);
         $leadFieldAlias            = 'field_alias';
         $fieldId                   = 1224;
-        $exceptionMessage          = 'Exception!';
         $actionProperties          = [SettingsType::FIELD => $fieldId, SettingsType::CHECKBOX => '0'];
 
         $config->expects(self::once())
@@ -518,25 +512,19 @@ class FormActionTest extends TestCase
             ->method('getAlias')
             ->willReturn($leadFieldAlias);
 
-        $translator->expects(self::once())
-            ->method('trans')
-            ->with(FormAction::NON_EXISTING_LIST)
-            ->willReturn($exceptionMessage);
-
         $segmentsModel->expects(self::once())
             ->method('getSegments')
             ->with($fieldId, false)
-            ->willThrowException(new NonExistingListException());
+            ->willReturn([]);
 
-        $leadModel->expects(self::never())
-            ->method('getLists');
+        $leadModel->expects(self::once())
+            ->method('getLists')
+            ->willReturn([]);
+
         $leadModel->expects(self::never())
             ->method('removeFromLists');
         $leadModel->expects(self::never())
             ->method('addToLists');
-
-        $this->expectException(ValidationException::class);
-        $this->expectExceptionMessage($exceptionMessage);
 
         $formAction = new FormAction($config, $leadFieldChoiceLoader, $translator, $leadModel, $segmentsModel);
         $formAction->onAction($event);

--- a/Tests/Unit/Model/SegmentsModelTest.php
+++ b/Tests/Unit/Model/SegmentsModelTest.php
@@ -87,7 +87,7 @@ class SegmentsModelTest extends TestCase
      *
      * @dataProvider invalidSegmentData
      */
-    public function testInvalidSegmentsReturnsNull(array $segmentsData): void
+    public function testInvalidSegmentsReturnsEmptyArray(array $segmentsData): void
     {
         $fieldId               = 123;
         $segmentAlias          = 'segment_alias';
@@ -114,7 +114,7 @@ class SegmentsModelTest extends TestCase
             ->method('saveEntity');
 
         $segmentsModel = new SegmentsModel($listModel, $leadFieldChoiceLoader);
-        self::assertNull($segmentsModel->getSegments($fieldId, false));
+        self::assertSame([], $segmentsModel->getSegments($fieldId, false));
     }
 
     public function testNotExistingSegmentAndNoCreateNewSegments(): void
@@ -144,13 +144,8 @@ class SegmentsModelTest extends TestCase
         $listModel->expects(self::never())
             ->method('saveEntity');
 
-        $this->expectException(NonExistingListException::class);
-        $this->expectExceptionMessage('Segment does not exist.');
-
         $segmentsModel = new SegmentsModel($listModel, $leadFieldChoiceLoader);
-        $segmentsModel->getSegments($fieldId, false);
-
-        self::fail('After exception.');
+        self::assertSame([], $segmentsModel->getSegments($fieldId, false));
     }
 
     public function testGetSegmentsOk(): void

--- a/Tests/Unit/Model/SegmentsModelTest.php
+++ b/Tests/Unit/Model/SegmentsModelTest.php
@@ -11,7 +11,6 @@ use Mautic\LeadBundle\Entity\LeadField;
 use Mautic\LeadBundle\Entity\LeadList;
 use Mautic\LeadBundle\Model\ListModel;
 use MauticPlugin\LeuchtfeuerMultiselectHandlingBundle\Exception\InvalidSetupException;
-use MauticPlugin\LeuchtfeuerMultiselectHandlingBundle\Exception\NonExistingListException;
 use MauticPlugin\LeuchtfeuerMultiselectHandlingBundle\Form\Loader\LeadFieldChoiceLoader;
 use MauticPlugin\LeuchtfeuerMultiselectHandlingBundle\Model\SegmentsModel;
 use PHPUnit\Framework\MockObject\MockObject;


### PR DESCRIPTION
This PR changes:
- Fixing the create missing segments switch (it didn't work when set to NO)
- QA finding: Missing segments should be ignored and form should be successfully submitted